### PR TITLE
[Fix Issue 20] MBRShadowing bit for Pyrite

### DIFF
--- a/pkg/core/feature/feature.go
+++ b/pkg/core/feature/feature.go
@@ -51,6 +51,7 @@ type Locking struct {
 	MediaEncryption  bool
 	MBREnabled       bool
 	MBRDone          bool
+	MBRShadowing     bool
 }
 
 type CommonSSC struct {
@@ -168,6 +169,8 @@ func ReadLockingFeature(rdr io.Reader) (*Locking, error) {
 	f.MediaEncryption = raw&0x8 > 0
 	f.MBREnabled = raw&0x10 > 0
 	f.MBRDone = raw&0x20 > 0
+	// MBRShadowing bit defined in Pyrite at least.
+	f.MBRShadowing = raw&0x40 > 0
 	return f, nil
 }
 


### PR DESCRIPTION
Add MBRShadowing bit to LockingFeature.
This allows in case of Pyrite SSC use the status of support for MBRShadowing (#20 )

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>