### PR TITLE
stream.go: ignore EmptyAtom tokens

### DIFF
--- a/pkg/core/method/method.go
+++ b/pkg/core/method/method.go
@@ -59,6 +59,11 @@ var (
 	ErrMethodStatusAuthorityLockedOut  = MethodStatusCodeMap[0x12]
 )
 
+type Call interface {
+	MarshalBinary() ([]byte, error)
+	IsEOS() bool
+}
+
 type MethodCall struct {
 	buf bytes.Buffer
 	// Used to verify detect programming errors
@@ -82,6 +87,10 @@ func (m *MethodCall) Clone() *MethodCall {
 	mn := &MethodCall{bytes.Buffer{}, m.depth, m.flags}
 	mn.buf.Write(m.buf.Bytes())
 	return mn
+}
+
+func (m *MethodCall) IsEOS() bool {
+	return false
 }
 
 func (m *MethodCall) StartList() {
@@ -175,4 +184,15 @@ func (m *MethodCall) MarshalBinary() ([]byte, error) {
 		return nil, ErrMethodListUnbalanced
 	}
 	return mn.buf.Bytes(), nil
+}
+
+type EOSMethodCall struct {
+}
+
+func (m *EOSMethodCall) MarshalBinary() ([]byte, error) {
+	return stream.Token(stream.EndOfSession), nil
+}
+
+func (m *EOSMethodCall) IsEOS() bool {
+	return true
 }

--- a/pkg/core/stream/stream.go
+++ b/pkg/core/stream/stream.go
@@ -168,10 +168,16 @@ func internalDecode(b []byte, depth int) (List, []byte, error) {
 		} else if b[0]&0xF0 == 0xF0 {
 			// Token
 			x = TokenType(uint8(b[0]))
+			// according to 3.2.2.3.1.5 Empty Atom, EmptyAtom "SHALL be ignored"
+			if x == EmptyAtom {
+				x = nil
+			}
 		} else {
 			return nil, nil, fmt.Errorf("unknown atom 0x%02x", b[0])
 		}
-		res = append(res, x)
+		if x != nil {
+			res = append(res, x)
+		}
 		b = b[s:]
 	}
 	return res, b, nil


### PR DESCRIPTION
For some drives we see that the response contains some EmptyTokens
The parsing done today expect status in specific location from
the end of reply and these tokens parse reply as malformed.

This fix will skip EmptyAtoms if exist when decoding the buffer

according to 3.2.2.3.1.5 Empty Atom:

The Empty atom does not encode values.
The Empty atom allows other values in the data subpacket
contained in that part of the stream to be aligned with multi-byte
boundaries for efficiency. It also allows areas of a fixed buffer to
be filled with a value that is able to be safely ignored.


Identified on **Kioxia**:
    "Protocol": "NVMe",                                                                                                                                                                                    
    "Model": "KCM6FRUL960G",                                                                                                                                                                               
    "Firmware": "0106"                                                                                                                                                                                     
