### PR TITLE
PM1735 missing Shadow MBR feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,25 +165,25 @@ func main() {
 
 These drives have been found to work without issues
 
-| Manufacturer | Model | Transport | Features |
-|--------------|-------|-----------|----------|
-| Corsair | Force MP510 | NVMe | Pyrite v1 |
-| Intel | P4510 (SSDPE2KX020T8O) | NVMe | Opal v2 |
-| Intel | P4610 (SSDPE2KE032T8O) | NVMe | Opal v2 |
-| Sabrent | Rocket 4.0 2TB | NVMe | Pyrite v2 |
-| Samsung | PM1735 (MZPLJ12THALA-00007) | NVMe | Opal v2 |
-| Samsung | PM961 (MZVLW512HMJP-000L7) | NVMe | Opal v2 |
-| Samsung | PM981 (MZVLB512HAJQ-000L7) | NVMe | Opal v2 |
-| Samsung | PM983 (MZ1LB1T9HALS-00007) | NVMe | Opal v2 |
-| Samsung | PM9A1 (MZVL2256HCHQ-00B00) | NVMe | Pyrite v2 |
-| Samsung | PM9A3 (MZQL23T8HCLS-00A07) | NVMe | Opal v2 |
-| Samsung | SSD 860 | SATA | Opal v2 |
-| Samsung | SSD 970 EVO Plus | NVMe | Opal v2 |
-| Samsung | SSD 980 Pro (MZVL2250HCHQ) | NVMe | Opal v2 |
-| Seagate | 7E2000 (ST2000NX0343) | SAS3 | Enterprise |
-| Seagate | Exos X14 (ST10000NM0608) | SAS3 | Enterprise |
-| Seagate | Momentus Thin (ST500LT015) | SATA | Opal v2 |
-| SK hynix | PC611 (HFS001TD9TNI-L2B0B) | NVMe | Opal v2 |
-| Toshiba | MG08SCP16TE | SAS3 | Enterprise |
+| Manufacturer | Model | Transport | Features | Notes |
+|--------------|-------|-----------|----------|-------|
+| Corsair | Force MP510 | NVMe | Pyrite v1 | |
+| Intel | P4510 (SSDPE2KX020T8O) | NVMe | Opal v2 | |
+| Intel | P4610 (SSDPE2KE032T8O) | NVMe | Opal v2 | |
+| Sabrent | Rocket 4.0 2TB | NVMe | Pyrite v2 | |
+| Samsung | PM1735 (MZPLJ12THALA-00007) | NVMe | Opal v2 | Shadow MBR missing |
+| Samsung | PM961 (MZVLW512HMJP-000L7) | NVMe | Opal v2 | |
+| Samsung | PM981 (MZVLB512HAJQ-000L7) | NVMe | Opal v2 | |
+| Samsung | PM983 (MZ1LB1T9HALS-00007) | NVMe | Opal v2 | |
+| Samsung | PM9A1 (MZVL2256HCHQ-00B00) | NVMe | Pyrite v2 | |
+| Samsung | PM9A3 (MZQL23T8HCLS-00A07) | NVMe | Opal v2 | |
+| Samsung | SSD 860 | SATA | Opal v2 | |
+| Samsung | SSD 970 EVO Plus | NVMe | Opal v2 | |
+| Samsung | SSD 980 Pro (MZVL2250HCHQ) | NVMe | Opal v2 | |
+| Seagate | 7E2000 (ST2000NX0343) | SAS3 | Enterprise | |
+| Seagate | Exos X14 (ST10000NM0608) | SAS3 | Enterprise | |
+| Seagate | Momentus Thin (ST500LT015) | SATA | Opal v2 | |
+| SK hynix | PC611 (HFS001TD9TNI-L2B0B) | NVMe | Opal v2 | |
+| Toshiba | MG08SCP16TE | SAS3 | Enterprise | |
 
 *Samsung PNs ending in "7" seems to indicate Opal v2 features*


### PR DESCRIPTION
Samsung isn't fully OPAL v2 compliant on PM1735 as they intentionally skipped Shadow MBR support in firmware for the these drives.