### PR TITLE
fix(ci): Remove duplicated `pull_request` statement in `golangci-lint.yml`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,7 +7,6 @@ on:
     tags: [ 'v*' ]
     branches: [ 'main' ]
 
-  pull_request:
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/pkg/cmdutil/resolver.go
+++ b/pkg/cmdutil/resolver.go
@@ -13,7 +13,7 @@ import (
 // If confirm is true, the user is prompted to enter the password twice for confirmation.
 func ResolvePassword(confirm bool) kong.Resolver {
 	return kong.ResolverFunc(func(ctx *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
-		if flag.Tag.Type != "password" || !flag.Required || flag.Value.Set && !flag.Value.Target.IsZero() {
+		if flag.Tag.Type != "password" || !flag.Required || flag.Set && !flag.Target.IsZero() {
 			return nil, nil
 		}
 


### PR DESCRIPTION
The superfluous `pull_request` leads to errors in the gitlab actions. See: https://github.com/open-source-firmware/go-tcg-storage/actions/runs/16717059513